### PR TITLE
[PS-6468] Removing send on enter from Android

### DIFF
--- a/src/MentionsTextInput.js
+++ b/src/MentionsTextInput.js
@@ -577,7 +577,7 @@ export default class MentionsTextInput extends Component {
       return;
     }
 
-    if (this.hasNewLineChar(text)) {
+    if (this.hasNewLineChar(text) && Platform.OS == 'ios') {
       this.props.onKeyPress({ nativeEvent: { key: "Enter" } });
       return;
     }


### PR DESCRIPTION
Making the "Send on Enter" behavior iOS only per discussion with Sam.

Android allows for multiline inputs in multiline text and Messenger, Text Messages, Discord and more chat apps all follow this behavior on Android.

Behavior was tested with mentions and on iOS as well with this change and this change doesn't appear to have caused any new issues.

![android keyboard behavior 2](https://user-images.githubusercontent.com/25853235/62248250-83dbc900-b39c-11e9-9726-b23392107379.gif)
![android keyboard behavior](https://user-images.githubusercontent.com/25853235/62248251-83dbc900-b39c-11e9-9ab9-c410f098d79e.gif)
