### PR TITLE
[PS-11365] added accessibility for textInput

### DIFF
--- a/src/MentionsTextInput.js
+++ b/src/MentionsTextInput.js
@@ -637,6 +637,7 @@ export default class MentionsTextInput extends Component {
           onContentSizeChange={this.onContentSizeChange.bind(this)}
           ref={component => this._textInput = component}
           accessibilityLabel={ 'chat_input_text' }
+          accessible={true}
           onChangeText={this.onChangeText.bind(this)}
           onSelectionChange={(event) => { this.onSelectionChange(event.nativeEvent.selection); }}
           disableFullscreenUI={!!this.props.disableFullscreenUI}


### PR DESCRIPTION
## Changes made
- Made the text input for muted chat accessible
- Jesse can now access the value of the text input

## How were the changes tested locally? 
- Jesse goes into appium and can access the value of the muted chat bar text
- ac_id('chat_input_text').text outputs, You have been muted.

![Screen Shot 2019-10-28 at 4 43 21 PM](https://user-images.githubusercontent.com/18249360/67726234-640b6f80-f9a2-11e9-93c1-7120b6e5096c.png)

